### PR TITLE
Add GitLab CI pipeline for tests and build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,28 @@
+image: mcr.microsoft.com/vscode/devcontainers/typescript-node:0-20
+
+stages:
+  - test
+  - build
+
+cache:
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+    - node_modules/
+
+Test:
+  stage: test
+  script:
+    - npm ci
+    - npm test
+
+Build:
+  stage: build
+  needs: ["Test"]
+  script:
+    - npm ci
+    - npm run package
+    - npx --yes @vscode/vsce package
+  artifacts:
+    name: "Build"
+    paths:
+      - "*.vsix"


### PR DESCRIPTION
## Summary
- add GitLab CI config with test and build stages
- build VS Code extension only after successful tests and publish VSIX artifact

## Testing
- `npm test` *(fails: Module not found: Can't resolve './src/tableEditor.ts')*

------
https://chatgpt.com/codex/tasks/task_e_689eabe47c088330ab647e3859b3a265